### PR TITLE
feat: add PriceOracle.sol to testnet

### DIFF
--- a/.github/actions/check-abi-naming/action.yml
+++ b/.github/actions/check-abi-naming/action.yml
@@ -1,0 +1,15 @@
+name: 'Check ABI File Naming'
+description: 'Ensures ABI files follow the naming convention: ContractName.abi.json'
+runs:
+  using: 'composite'
+  steps:
+    - name: Check ABI file naming
+      shell: bash
+      run: |
+        for FILE in $(find . -name "*.abi.json"); do
+          BASENAME=$(basename "$FILE")
+          if [[ ! $BASENAME =~ ^[A-Za-z0-9]+\.abi\.json$ ]]; then
+            echo "Error: ABI file '$BASENAME' does not follow the naming convention 'ContractName.abi.json'"
+            exit 1
+          fi
+        done

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ out/
 
 # Ignores development broadcast logs
 !/broadcast
+broadcast/*
 /broadcast/*/31337/
 /broadcast/**/dry-run/
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "lib/v2-core"]
+	path = lib/v2-core
+	url = https://github.com/uniswap/v2-core

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ git pull origin main
 Install the dependency submodules using Forge:
 
 ```shell
-forge install --no-commit foundry-rs/forge-std openzeppelin/openzeppelin-contracts
+forge install --no-commit foundry-rs/forge-std openzeppelin/openzeppelin-contracts uniswap/v2-core uniswap v3-core uniswap v3-periphery
 ```
 
 The `foundry.toml` file is used to configure Foundry settings, manage RPC endpoints, and dependencies.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Then run the `forge script` command without the private key arg.
 
 ## Contributing
 
-[![PRs Closed](https://img.shields.io/badge/PRs-closed-darkgreen.svg)]
+![PRs Open](https://img.shields.io/badge/PRs-open-darkgreen.svg)
 
 If you are an Solidity developer and are interested in auditing our `v1-core` contracts, you can submit an audit by using the form [here](https://github.com/xeon-protocol/xeon-dapp/issues/new?assignees=heyJonBray%2C+wellytg%2C+neonhedge&labels=type%3A+audit%2C+status%3A+discussing&projects=&template=04-audit-submission.md&title=xeon-xeon-v1+audit+%5BMM-DD-YYYY%5D-%5ByourName%5D).
 

--- a/abi/PriceOracle.abi.json
+++ b/abi/PriceOracle.abi.json
@@ -1,0 +1,148 @@
+[
+  { "inputs": [], "stateMutability": "nonpayable", "type": "constructor" },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "price",
+        "type": "uint256"
+      }
+    ],
+    "name": "PriceUpdated",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "WETH",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" }
+    ],
+    "name": "getValueInWETH",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oDEGEN",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oHIGHER",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oPEPE",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oROR",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oVELA",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "priceInWETH", "type": "uint256" }
+    ],
+    "name": "setTokenPriceInWETH",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "priceInUSD", "type": "uint256" }
+    ],
+    "name": "setWETHPriceInUSD",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/foundry.toml
+++ b/foundry.toml
@@ -13,6 +13,9 @@ show_progress = true
 remappings = [
     "@forge-std/=lib/forge-std/src/",
     "@openzeppelin/=lib/openzeppelin-contracts/",
+    "@uniswap/v2-core/=lib/v2-core/",
+    "@uniswap/v3-core/=lib/v3-core/",
+    "@uniswap/v3-periphery/=lib/v3-periphery/"
 ]
 
 [rpc_endpoints]

--- a/script/PriceOracle.s.sol
+++ b/script/PriceOracle.s.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.20;
+
+import {Script, console2} from "@forge-std/Script.sol";
+import {PriceOracle} from "../src/PriceOracle.sol";
+
+contract PriceOracleScript is Script {
+    address public deployer = 0x56557c3266d11541c2D939BF6C05BFD29e881e55;
+
+    // base sepolia
+    // simulate: forge script script/PriceOracle.s.sol:PriceOracleScript --rpc-url $BASE_SEPOLIA_RPC_URL --chain-id 84532 -vvvv
+    // broadcast: forge script script/PriceOracle.s.sol:PriceOracleScript --rpc-url $BASE_SEPOLIA_RPC_URL --chain-id 84532 -vv --broadcast --verify
+
+    function setUp() public {}
+
+    function run() public {
+        vm.startBroadcast(vm.envUint("DEPLOYER_PRIVATE_KEY"));
+
+        console2.log("deploying PriceOracle contract...");
+        PriceOracle priceOracle = new PriceOracle();
+
+        console2.log("PriceOracle deployed at:", address(priceOracle));
+
+        vm.stopBroadcast();
+    }
+}

--- a/src/PriceOracle.sol
+++ b/src/PriceOracle.sol
@@ -19,12 +19,9 @@ contract PriceOracle is Ownable {
 
     //==================== MAPPINGS ====================//
     mapping(address => uint256) private tokenPrices;
-    mapping(address => bool) public admins;
 
     //===================== EVENTS =====================//
     event PriceUpdated(address indexed token, uint256 price);
-    event AdminAdded(address indexed admin);
-    event AdminRemoved(address indexed admin);
 
     //================== CONSTRUCTOR ==================//
     constructor() Ownable(msg.sender) {
@@ -35,23 +32,7 @@ contract PriceOracle is Ownable {
         tokenPrices[oROR] = 0;
     }
 
-    //================ MODIFIERS =================//
-    modifier onlyAdmin() {
-        require(admins[msg.sender], "Caller is not an admin");
-        _;
-    }
-
     //================ EXTERNAL FUNCTIONS ================//
-    function addAdmin(address admin) external onlyOwner {
-        admins[admin] = true;
-        emit AdminAdded(admin);
-    }
-
-    function removeAdmin(address admin) external onlyOwner {
-        admins[admin] = false;
-        emit AdminRemoved(admin);
-    }
-
     /**
      * @notice Sets the price of a token in WETH
      * @param token The address of the token
@@ -66,16 +47,12 @@ contract PriceOracle is Ownable {
      * @notice Sets the price of WETH in USD
      * @param priceInUSD The price of WETH in USD
      */
-    function setWETHPriceInUSD(uint256 priceInUSD) external onlyAdmin {
+    function setWETHPriceInUSD(uint256 priceInUSD) external onlyOwner {
         tokenPrices[WETH] = priceInUSD;
         emit PriceUpdated(WETH, priceInUSD);
     }
 
     //==================== GETTERS ====================//
-    function getAdminStatus(address admin) external view returns (bool) {
-        return admins[admin];
-    }
-
     function getValueInWETH(address token) external view returns (uint256) {
         return tokenPrices[token];
     }

--- a/src/PriceOracle.sol
+++ b/src/PriceOracle.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/*
+ * @title Xeon Price Oracle (Testnet)
+ * @author Jon Bray <jon@xeon-protocol.io>
+ * @notice this is a testnet price oracle that allows for manual price changes
+ */
+contract PriceOracle is Ownable {
+    //==================== STATE VARIABLES ====================//
+    address public constant oVELA = 0xb7E16D46f26B1615Dcc501931F28F07fD4b0D7F4;
+    address public constant oPEPE = 0x7dC9ecE25dcCA41D8a627cb47ded4a9322f7722b;
+    address public constant oDEGEN = 0x9B9852A943a570685c3704d70C4F1ebD5EdE109B;
+    address public constant oHIGHER = 0x9855d38b7E6270B9f22F283A0C62330b16Ac909C;
+    address public constant oROR = 0xEb2DCAFFFf1b0d5BA76F14Fe6bB8348126339FcB;
+    address public constant WETH = 0x395cB7753B02A15ed1C099DFc36bF00171F18218;
+
+    //==================== MAPPINGS ====================//
+    mapping(address => uint256) private tokenPrices;
+    mapping(address => bool) public admins;
+
+    //===================== EVENTS =====================//
+    event PriceUpdated(address indexed token, uint256 price);
+    event AdminAdded(address indexed admin);
+    event AdminRemoved(address indexed admin);
+
+    //================== CONSTRUCTOR ==================//
+    constructor() Ownable(msg.sender) {
+        tokenPrices[oVELA] = 0;
+        tokenPrices[oPEPE] = 0;
+        tokenPrices[oDEGEN] = 0;
+        tokenPrices[oHIGHER] = 0;
+        tokenPrices[oROR] = 0;
+    }
+
+    //================ MODIFIERS =================//
+    modifier onlyAdmin() {
+        require(admins[msg.sender] || owner() == msg.sender, "Caller is not an admin");
+        _;
+    }
+
+    //================ EXTERNAL FUNCTIONS ================//
+    function addAdmin(address admin) external onlyOwner {
+        admins[admin] = true;
+        emit AdminAdded(admin);
+    }
+
+    function removeAdmin(address admin) external onlyOwner {
+        admins[admin] = false;
+        emit AdminRemoved(admin);
+    }
+
+    /**
+     * @notice Sets the price of a token in WETH
+     * @param token The address of the token
+     * @param priceInWETH The price of the token in WETH
+     */
+    function setWETHPrice(address token, uint256 priceInWETH) external onlyAdmin {
+        tokenPrices[token] = priceInWETH;
+        emit PriceUpdated(token, priceInWETH);
+    }
+
+    /**
+     * @notice Sets the price of WETH in USD
+     * @param priceInUSD The price of WETH in USD
+     */
+    function setWETHPriceInUSD(uint256 priceInUSD) external onlyAdmin {
+        tokenPrices[WETH] = priceInUSD;
+        emit PriceUpdated(WETH, priceInUSD);
+    }
+
+    //==================== GETTERS ====================//
+    function getAdminStatus(address admin) external view returns (bool) {
+        return admins[admin];
+    }
+
+    function getValueInWETH(address token) external view returns (uint256) {
+        return tokenPrices[token];
+    }
+}

--- a/src/PriceOracle.sol
+++ b/src/PriceOracle.sol
@@ -37,7 +37,7 @@ contract PriceOracle is Ownable {
 
     //================ MODIFIERS =================//
     modifier onlyAdmin() {
-        require(admins[msg.sender] || owner() == msg.sender, "Caller is not an admin");
+        require(admins[msg.sender], "Caller is not an admin");
         _;
     }
 
@@ -57,7 +57,7 @@ contract PriceOracle is Ownable {
      * @param token The address of the token
      * @param priceInWETH The price of the token in WETH
      */
-    function setWETHPrice(address token, uint256 priceInWETH) external onlyAdmin {
+    function setTokenPriceInWETH(address token, uint256 priceInWETH) external onlyOwner {
         tokenPrices[token] = priceInWETH;
         emit PriceUpdated(token, priceInWETH);
     }

--- a/test/PriceOracle.t.sol
+++ b/test/PriceOracle.t.sol
@@ -7,58 +7,41 @@ import "../src/PriceOracle.sol";
 contract PriceOracleTest is Test {
     PriceOracle private priceOracle;
     address private owner = address(0x123);
-    address private admin = address(0x456);
     address private nonAdmin = address(0x789);
 
     function setUp() public {
         vm.startPrank(owner);
         priceOracle = new PriceOracle();
-        priceOracle.addAdmin(admin);
         vm.stopPrank();
     }
 
-    function test_SetTokenPriceInWETHByAdmin() public {
-        vm.startPrank(admin);
+    function test_SetTokenPriceInWETHByOwner() public {
+        vm.startPrank(owner);
         // set oROR price to 0.00001 WETH
         priceOracle.setTokenPriceInWETH(priceOracle.oROR(), 0.00001 * 10 ** 18);
         assertEq(priceOracle.getValueInWETH(priceOracle.oROR()), 0.00001 * 10 ** 18);
         vm.stopPrank();
     }
 
-    function test_SetWETHPriceInUSDByAdmin() public {
-        vm.startPrank(admin);
+    function test_SetWETHPriceInUSDByOwner() public {
+        vm.startPrank(owner);
         priceOracle.setWETHPriceInUSD(3000 * 10 ** 18);
-
         assertEq(priceOracle.getValueInWETH(priceOracle.WETH()), 3000 * 10 ** 18);
         vm.stopPrank();
     }
 
-    function test_NonAdminCannotSetTokenPriceInWETH() public {
+    function test_NonOwnerCannotSetTokenPriceInWETH() public {
         vm.startPrank(nonAdmin);
-        vm.expectRevert("Caller is not an admin");
-        // attempt to set oROR price as non-admin
+        vm.expectRevert("Ownable: caller is not the owner");
+        // attempt to set oROR price as non-owner
         priceOracle.setTokenPriceInWETH(priceOracle.oROR(), 0.00001 * 10 ** 18);
         vm.stopPrank();
     }
 
-    function test_NonAdminCannotSetWETHPriceInUSD() public {
+    function test_NonOwnerCannotSetWETHPriceInUSD() public {
         vm.startPrank(nonAdmin);
-        vm.expectRevert("Caller is not an admin");
+        vm.expectRevert("Ownable: caller is not the owner");
         priceOracle.setWETHPriceInUSD(3000 * 10 ** 18);
-        vm.stopPrank();
-    }
-
-    function test_NonAdminCannotAddAdmin() public {
-        vm.startPrank(nonAdmin);
-        vm.expectRevert("Ownable: caller is not the owner");
-        priceOracle.addAdmin(nonAdmin);
-        vm.stopPrank();
-    }
-
-    function test_NonAdminCannotRemoveAdmin() public {
-        vm.startPrank(nonAdmin);
-        vm.expectRevert("Ownable: caller is not the owner");
-        priceOracle.removeAdmin(admin);
         vm.stopPrank();
     }
 }

--- a/test/PriceOracle.t.sol
+++ b/test/PriceOracle.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
+import "@forge-std/Test.sol";
 import "../src/PriceOracle.sol";
 
 contract PriceOracleTest is Test {

--- a/test/PriceOracle.t.sol
+++ b/test/PriceOracle.t.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../src/PriceOracle.sol";
+
+contract PriceOracleTest is Test {
+    PriceOracle private priceOracle;
+    address private owner = address(0x123);
+    address private admin = address(0x456);
+    address private nonAdmin = address(0x789);
+
+    function setUp() public {
+        vm.startPrank(owner);
+        priceOracle = new PriceOracle();
+        priceOracle.addAdmin(admin);
+        vm.stopPrank();
+    }
+
+    function test_SetTokenPriceInWETHByAdmin() public {
+        vm.startPrank(admin);
+        // set oROR price to 0.00001 WETH
+        priceOracle.setTokenPriceInWETH(priceOracle.oROR(), 0.00001 * 10 ** 18);
+        assertEq(priceOracle.getValueInWETH(priceOracle.oROR()), 0.00001 * 10 ** 18);
+        vm.stopPrank();
+    }
+
+    function test_SetWETHPriceInUSDByAdmin() public {
+        vm.startPrank(admin);
+        priceOracle.setWETHPriceInUSD(3000 * 10 ** 18);
+
+        assertEq(priceOracle.getValueInWETH(priceOracle.WETH()), 3000 * 10 ** 18);
+        vm.stopPrank();
+    }
+
+    function test_NonAdminCannotSetTokenPriceInWETH() public {
+        vm.startPrank(nonAdmin);
+        vm.expectRevert("Caller is not an admin");
+        // attempt to set oROR price as non-admin
+        priceOracle.setTokenPriceInWETH(priceOracle.oROR(), 0.00001 * 10 ** 18);
+        vm.stopPrank();
+    }
+
+    function test_NonAdminCannotSetWETHPriceInUSD() public {
+        vm.startPrank(nonAdmin);
+        vm.expectRevert("Caller is not an admin");
+        priceOracle.setWETHPriceInUSD(3000 * 10 ** 18);
+        vm.stopPrank();
+    }
+
+    function test_NonAdminCannotAddAdmin() public {
+        vm.startPrank(nonAdmin);
+        vm.expectRevert("Ownable: caller is not the owner");
+        priceOracle.addAdmin(nonAdmin);
+        vm.stopPrank();
+    }
+
+    function test_NonAdminCannotRemoveAdmin() public {
+        vm.startPrank(nonAdmin);
+        vm.expectRevert("Ownable: caller is not the owner");
+        priceOracle.removeAdmin(admin);
+        vm.stopPrank();
+    }
+}

--- a/test/PriceOracle.t.sol
+++ b/test/PriceOracle.t.sol
@@ -6,8 +6,8 @@ import "../src/PriceOracle.sol";
 
 contract PriceOracleTest is Test {
     PriceOracle private priceOracle;
-    address private owner = address(0x123);
-    address private nonAdmin = address(0x789);
+    address private owner = address(0x420);
+    address private user1 = address(0x069);
 
     function setUp() public {
         vm.startPrank(owner);
@@ -30,17 +30,15 @@ contract PriceOracleTest is Test {
         vm.stopPrank();
     }
 
-    function test_NonOwnerCannotSetTokenPriceInWETH() public {
-        vm.startPrank(nonAdmin);
-        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", nonAdmin));
+    function testFailNonOwnerSetTokenPrice() public {
+        vm.startPrank(user1);
         // attempt to set oROR price as non-owner
         priceOracle.setTokenPriceInWETH(priceOracle.oROR(), 0.00001 * 10 ** 18);
         vm.stopPrank();
     }
 
-    function test_NonOwnerCannotSetWETHPriceInUSD() public {
-        vm.startPrank(nonAdmin);
-        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", nonAdmin));
+    function testFailNonOwnerSetWETHPriceInUSD() public {
+        vm.startPrank(user1);
         priceOracle.setWETHPriceInUSD(3000 * 10 ** 18);
         vm.stopPrank();
     }

--- a/test/PriceOracle.t.sol
+++ b/test/PriceOracle.t.sol
@@ -32,7 +32,7 @@ contract PriceOracleTest is Test {
 
     function test_NonOwnerCannotSetTokenPriceInWETH() public {
         vm.startPrank(nonAdmin);
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", nonAdmin));
         // attempt to set oROR price as non-owner
         priceOracle.setTokenPriceInWETH(priceOracle.oROR(), 0.00001 * 10 ** 18);
         vm.stopPrank();
@@ -40,7 +40,7 @@ contract PriceOracleTest is Test {
 
     function test_NonOwnerCannotSetWETHPriceInUSD() public {
         vm.startPrank(nonAdmin);
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", nonAdmin));
         priceOracle.setWETHPriceInUSD(3000 * 10 ** 18);
         vm.stopPrank();
     }


### PR DESCRIPTION
this PR adds PriceOracle.sol with modified logic for testnet that allows for manual price setting in the absence of Uniswap pairs and TWAP volume on Base Sepolia

when merged, this closes #1